### PR TITLE
infra: Add workflow to automate PR labelling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,33 @@
+topic/functions:
+  - content/chapters/functions/**/*
+
+topic/multivar-power:
+  - content/chapters/multivariate-to-power/**/*
+
+topic/numbers-indices:
+  - content/chapters/numbers-to-indices/**/*
+
+topic/vectors-matrix:
+  - content/chapters/vectors-matrix-ops/**/*
+
+area/quiz:
+  - '**/quiz/*'
+
+area/content:
+  - '*.md'
+  - '**/media/**/*'
+  - '**/*.mdpp'
+
+area/code:
+  - '**/lab/support/**/*'
+  - '**/lab/solution/**/*'
+  - '**/lecture/demo/**/*'
+
+area/infra:
+  - 'util/**/*'
+  - '.github/**/*'
+  - 'Dockerfile'
+  - 'config.yaml'
+
+area/assignment:
+  - content/assignments/**/*

--- a/.github/scripts/add-labels.js
+++ b/.github/scripts/add-labels.js
@@ -1,0 +1,59 @@
+async function getPRFileData(github, context, pr) {
+    return await github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/files', {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: pr
+    })
+}
+
+function addLabelToList(labels, label) {
+    if (!labels.includes(label)) {
+        labels.push(label)
+    }
+}
+
+async function createLabelsForPR(github, context, pr) {
+    var labels = []
+
+    await getPRFileData(github, context, pr).then((data) => {
+        data.data.forEach((file) => {
+            if (file.status === 'added') {
+                addLabelToList(labels, 'kind/new')
+            }
+            else if (file.status === 'modified' && file.deletions === 0 && file.additions > 0) {
+                addLabelToList(labels, 'kind/improve')
+            }
+        })
+    })
+
+    return labels
+}
+
+async function addLabelsToPR(github, context, pr, labels) {
+    if (labels.length === 0) {
+        return
+    }
+
+    await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/labels', {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: pr,
+        labels: labels
+    })
+}
+
+export default async function assignLabelsToPRs({github, context})
+{
+    await github.request('GET /repos/{owner}/{repo}/pulls', {
+        owner: context.repo.owner,
+        repo: context.repo.repo
+    }).then((prs) => { prs.data.forEach(async (pr) => {
+        if (pr.state == 'open') {
+            const prNum = pr.number
+            const labels = await createLabelsForPR(github, context, prNum)
+            if (labels.length > 0) {
+                await addLabelsToPR(github, context, prNum, labels)
+            }
+        }
+    })})
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: "Pull Request Labeler"
+
+on:
+  schedule:
+  - cron: "0 */12 * * *"
+  workflow_dispatch:
+
+jobs:
+  add-topic-area-labels:
+    name: Add topic and area labels
+    runs-on: ubuntu-latest
+    steps:
+    - uses: fjeremic/cron-labeler@0.2.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  add-kind-labels:
+    name: Add kind labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const { default: assignLabelsToPRs } = await import('${{ github.workspace }}/.github/scripts/add-labels.js') ;
+            await assignLabelsToPRs({github, context})


### PR DESCRIPTION
This workflow uses the `labeler.yml` file to assign static labels according to file paths and extensions.
It also runs a `cron` job every 12 hours that adds the `kind/*` labels.